### PR TITLE
Accept acestream URLs

### DIFF
--- a/Ace Link/AppDelegate.swift
+++ b/Ace Link/AppDelegate.swift
@@ -1,9 +1,20 @@
 import Cocoa
 
+
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
 
+    private enum Constants {
+      static let aceStreamProtocol = "acestream"
+      static let aceStreamUrlBeginning = Constants.aceStreamProtocol + "://"
+      
+    }
+  
     let statusItem = NSStatusBar.system.statusItem(withLength:NSStatusItem.squareLength)
+
+    private func hashFromString(_ string:String) -> String {
+      return string.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: Constants.aceStreamUrlBeginning, with: "")
+    }
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         print("Application finished loading")
@@ -19,6 +30,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         statusItem.menu = AceLinkMenu(title: "")
+
     }
 
     func openStream(_ hash: String) {
@@ -46,7 +58,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return ""
         }
 
-      let clipboardString: String = clipboardData!.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: "acestream://", with: "")
+      let clipboardString: String = hashFromString(clipboardData!)
 
         // Verify conform SHA1
         let range = NSMakeRange(0, clipboardString.count)
@@ -66,4 +78,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         stopStream()
     }
 
+  
+  
+    /** 10.3 or Higher **/
+    func application(_ application: NSApplication, open urls: [URL]) {
+      guard let url = urls.first, let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: true) ,  urlComponents.scheme == Constants.aceStreamProtocol else {
+        return
+      }
+      openStream(hashFromString(url.absoluteString))
+    }
 }

--- a/Ace Link/AppDelegate.swift
+++ b/Ace Link/AppDelegate.swift
@@ -46,7 +46,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return ""
         }
 
-        let clipboardString: String = clipboardData!.trimmingCharacters(in: .whitespacesAndNewlines)
+      let clipboardString: String = clipboardData!.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: "acestream://", with: "")
 
         // Verify conform SHA1
         let range = NSMakeRange(0, clipboardString.count)

--- a/Ace Link/Info.plist
+++ b/Ace Link/Info.plist
@@ -18,6 +18,19 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.1</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>AceStream link</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>acestream</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>2</string>
 	<key>LSApplicationCategoryType</key>


### PR DESCRIPTION
Two changes:

- Accept both an acestream id and a full acestream url from pasteboard. Helpful when copying/pasting  links directly from web pages
- Register "acestream" url scheme to open the app when a link is clicked in the browser.
  
