### PR TITLE
Fix healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN set -ex && \
         ca-certificates \
         python2.7 \
         libpython2.7 \
-        net-tools \
+        netcat \
         python-setuptools \
         python-m2crypto \
         python-apsw \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN set -ex && \
         ca-certificates \
         python2.7 \
         libpython2.7 \
-        netcat \
+        net-tools \
         python-setuptools \
         python-m2crypto \
         python-apsw \
@@ -46,7 +46,7 @@ RUN mkdir /acelink
 COPY acestream.conf /opt/acestream/acestream.conf
 ENTRYPOINT ["/opt/acestream/start-engine", "@/opt/acestream/acestream.conf"]
 
-HEALTHCHECK CMD nc -zv localhost 6878 || exit 1
+HEALTHCHECK CMD wget -nv -t1 --spider http://localhost:6878 || exit 1
 
 EXPOSE 6878
 EXPOSE 8621


### PR DESCRIPTION
Package `net-tools` does not include netcat, so `nc` command will fail when checking the container liveness.