### PR TITLE
Container stuck in "unhealthy" status

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,8 @@ RUN mkdir /acelink
 COPY acestream.conf /opt/acestream/acestream.conf
 ENTRYPOINT ["/opt/acestream/start-engine", "@/opt/acestream/acestream.conf"]
 
-HEALTHCHECK CMD wget -nv -t1 --spider http://localhost:6878 || exit 1
+HEALTHCHECK --interval=1m --timeout=3s --retries=3 \
+  CMD bash -c ':> /dev/tcp/127.0.0.1/6878' || exit 1
 
 EXPOSE 6878
 EXPOSE 8621

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,7 @@ RUN mkdir /acelink
 COPY acestream.conf /opt/acestream/acestream.conf
 ENTRYPOINT ["/opt/acestream/start-engine", "@/opt/acestream/acestream.conf"]
 
-HEALTHCHECK --interval=1m --timeout=3s --retries=3 \
-  CMD bash -c ':> /dev/tcp/127.0.0.1/6878' || exit 1
+HEALTHCHECK CMD wget -q -t1 -O- 'http://127.0.0.1:6878/webui/api/service?method=get_version' | grep '"error": null'
 
 EXPOSE 6878
 EXPOSE 8621


### PR DESCRIPTION
The API returns `501 Not Implemented` at every request done using `wget --spider`, so the container status is always *unhealthy*.

The bash command seems to solve the problem.

Source: https://medium.com/bash-tips-and-tricks/part01-tcp-udp-request-with-a-native-bash-feature-and-without-curl-wget-9dcef59c30aa