### PR TITLE
Dockerfile: bump Ubuntu to 22 & Python to 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1
-FROM --platform=linux/amd64 ubuntu:focal
+FROM --platform=linux/amd64 ubuntu:jammy
 
 ENV LC_ALL="C.UTF-8" \
     LANG="C.UTF-8" \
-    DOWNLOAD_URL="https://download.acestream.media/linux/acestream_3.2.3_ubuntu_18.04_x86_64_py3.8.tar.gz" \
-    CHECKSUM="bf45376f1f28aaff7d9849ff991bf34a6b9a65542460a2344a8826126c33727d"
+    DOWNLOAD_URL="https://download.acestream.media/linux/acestream_3.2.3_ubuntu_22.04_x86_64_py3.10.tar.gz" \
+    CHECKSUM="ad11060410c64f04c8412d7dc99272322f7a24e45417d4ef2644b26c64ae97c9"
 
 # Install system packages.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked\
@@ -12,13 +12,13 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked\
     --mount=type=tmpfs,target=/tmp\
     set -ex;\
     apt-get update;\
-    apt-get install -yq --no-install-recommends ca-certificates python3.8 libpython3.8 python3-pip wget;\
+    apt-get install -yq --no-install-recommends ca-certificates python3.10 libpython3.10 python3-pip wget;\
     mkdir -p /opt/acestream;\
     wget --no-verbose --output-document /opt/acestream/acestream.tgz $DOWNLOAD_URL;\
     echo "$CHECKSUM /opt/acestream/acestream.tgz" | sha256sum --check;\
     tar --extract --gzip --directory /opt/acestream --file /opt/acestream/acestream.tgz;\
     rm /opt/acestream/acestream.tgz;\
-    python3 -m pip install -r /opt/acestream/requirements.txt;\
+    python3 -m pip install --no-cache-dir -r /opt/acestream/requirements.txt;\
     /opt/acestream/start-engine --version;
 
 # Overwrite disfunctional Ace Stream web player with a working videojs player,


### PR DESCRIPTION
PR which bumps Ubuntu from Focal to Jammy and Python 3.8 to 3.10.

I did some testing implementing multi-stage, yet there is not much to gain as seen in PR https://github.com/blaise-io/acelink/pull/89. Using python-3-10-minimal resulted in increased size and there isn't a minimal Docker version of ubuntu images

The increased size of version bump is less than 2%
<img width="856" alt="diff" src="https://github.com/user-attachments/assets/48558ca1-f6e1-4512-baaf-4f5d3c7c7f2f" />
